### PR TITLE
ci: update to go version 1.17 from 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sonr-io/core
 
-go 1.16
+go 1.17
 
 require (
 	git.mills.io/prologic/bitcask v1.0.0


### PR DESCRIPTION

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>