### PR TITLE
Added Registry's missing query HTTP handlers

### DIFF
--- a/internal/highway/api/crud_registry.go
+++ b/internal/highway/api/crud_registry.go
@@ -26,6 +26,7 @@ func (s *HighwayServer) QueryWhoIs(c *gin.Context) {
 		}
 
 		c.JSON(http.StatusOK, res)
+		return
 	}
 
 	c.JSON(http.StatusBadRequest, gin.H{"error": "did is required"})
@@ -49,6 +50,7 @@ func (s *HighwayServer) QueryWhoIsController(c *gin.Context) {
 		}
 
 		c.JSON(http.StatusOK, res)
+		return
 	}
 
 	c.JSON(http.StatusBadRequest, gin.H{"error": "did is required"})
@@ -72,6 +74,7 @@ func (s *HighwayServer) QueryWhoIsAlias(c *gin.Context) {
 		}
 
 		c.JSON(http.StatusOK, res)
+		return
 	}
 
 	c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})

--- a/internal/highway/api/crud_registry.go
+++ b/internal/highway/api/crud_registry.go
@@ -8,6 +8,75 @@ import (
 	rt "github.com/sonr-io/sonr/x/registry/types"
 )
 
+// QueryWhoIs
+// @Summary
+// @Schemes
+// @Description QueryWhoIsDID
+// @Tags Registry
+// @Produce json
+// @Success      200  {string}  message
+// @Failure      500  {string}  message
+// @Router /registry/query/whois/:did [GET]
+func (s *HighwayServer) QueryWhoIs(c *gin.Context) {
+	if did := c.Param("did"); did != "" {
+		res, err := s.Cosmos.QueryWhoIs(did)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, res)
+	}
+
+	c.JSON(http.StatusBadRequest, gin.H{"error": "did is required"})
+}
+
+// QueryWhoIsController
+// @Summary
+// @Schemes
+// @Description QueryWhoIsDID
+// @Tags Registry
+// @Produce json
+// @Success      200  {string}  message
+// @Failure      500  {string}  message
+// @Router /registry/query/whois/controller/:did [GET]
+func (s *HighwayServer) QueryWhoIsController(c *gin.Context) {
+	if did := c.Param("did"); did != "" {
+		res, err := s.Cosmos.QueryWhoIs(did)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, res)
+	}
+
+	c.JSON(http.StatusBadRequest, gin.H{"error": "did is required"})
+}
+
+// QueryWhoIsAlias
+// @Summary
+// @Schemes
+// @Description QueryWhoIsDID
+// @Tags Registry
+// @Produce json
+// @Success      200  {string}  message
+// @Failure      500  {string}  message
+// @Router /registry/query/whois/alias/:name [GET]
+func (s *HighwayServer) QueryWhoIsAlias(c *gin.Context) {
+	if name := c.Param("name"); name != "" {
+		res, err := s.Cosmos.QueryWhoIs(name)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, res)
+	}
+
+	c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
+}
+
 // @Summary Create WhoIs Entry
 // @Schemes
 // @Description This method takes a DIDDocument as an input along with the did of the account calling the TX, and verifies the signature. If succesful, and there is no existing WhoIs created for the user or application. Paramaters include: signature, diddocument, address, and whoIsType.

--- a/internal/highway/api/crud_registry.go
+++ b/internal/highway/api/crud_registry.go
@@ -40,10 +40,10 @@ func (s *HighwayServer) QueryWhoIs(c *gin.Context) {
 // @Produce json
 // @Success      200  {string}  message
 // @Failure      500  {string}  message
-// @Router /registry/query/whois/controller/:did [GET]
+// @Router /registry/query/whois/controller/:controller [GET]
 func (s *HighwayServer) QueryWhoIsController(c *gin.Context) {
-	if did := c.Param("did"); did != "" {
-		res, err := s.Cosmos.QueryWhoIs(did)
+	if controller := c.Param("controller"); controller != "" {
+		res, err := s.Cosmos.QueryWhoIsController(controller)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -64,10 +64,10 @@ func (s *HighwayServer) QueryWhoIsController(c *gin.Context) {
 // @Produce json
 // @Success      200  {string}  message
 // @Failure      500  {string}  message
-// @Router /registry/query/whois/alias/:name [GET]
+// @Router /registry/query/whois/alias/:alias [GET]
 func (s *HighwayServer) QueryWhoIsAlias(c *gin.Context) {
-	if name := c.Param("name"); name != "" {
-		res, err := s.Cosmos.QueryWhoIs(name)
+	if alias := c.Param("alias"); alias != "" {
+		res, err := s.Cosmos.QueryWhoIsAlias(alias)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/internal/highway/highway.go
+++ b/internal/highway/highway.go
@@ -54,6 +54,12 @@ func NewHighway(ctx context.Context, opts ...config.Option) (*api.HighwayServer,
 	s.Router.POST("/v1/registry/whois/create", s.CreateWhoIs)
 	s.Router.POST("/v1/registry/whois/update", s.UpdateWhoIs)
 	s.Router.POST("/v1/registry/whois/deactivate", s.DeactivateWhoIs)
+	s.Router.POST("/v1/registry/whois/create", s.CreateWhoIs)
+	s.Router.POST("/v1/registry/whois/update", s.UpdateWhoIs)
+	s.Router.POST("/v1/registry/whois/deactivate", s.DeactivateWhoIs)
+	s.Router.POST("/v1/registry/query/whois/:did", s.QueryWhoIs)
+	s.Router.POST("/v1/registry/whois/controller/:did", s.QueryWhoIsController)
+	s.Router.POST("/v1/registry/whois/alias/:name", s.QueryWhoIsAlias)
 
 	// Setup Swagger UI
 	s.Router.GET("v1/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))


### PR DESCRIPTION
This adds the missing HTTP handlers for querying the registry, as below:

```
// Find a DIDDocument by ID
(GET): /v1/registry/query/whois/:did
- DID:string

// Find a DIDDocument with the matching controller
(GET): /v1/registry/query/whois/controller/:did
- DID:string

// Find a DIDDocument with the matching alias
(GET): /v1/registry/query/whois/alias/:name
- Name:string
```

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>