### PR TITLE
Created DID Query Methods

### DIFF
--- a/pkg/did/document.go
+++ b/pkg/did/document.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/duo-labs/webauthn/webauthn"
 	"github.com/sonr-io/sonr/pkg/did/ssi"
 
 	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/webauthn"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/shengdoushi/base58"
 	"github.com/sonr-io/sonr/pkg/did/internal/marshal"
@@ -75,6 +75,26 @@ func NewDocument(idStr string) (Document, error) {
 
 func (d *DocumentImpl) ControllerCount() int {
 	return len(d.Controller)
+}
+
+// FindAuthenticationMethod finds a VerificationMethod by its ID
+func (d *DocumentImpl) FindAuthenticationMethod(id DID) *VerificationMethod {
+	return d.Authentication.FindByID(id)
+}
+
+// FindAssertionMethod finds a VerificationMethod by its ID
+func (d *DocumentImpl) FindAssertionMethod(id DID) *VerificationMethod {
+	return d.AssertionMethod.FindByID(id)
+}
+
+// FindCapabilityDelegation finds a VerificationMethod by its ID
+func (d *DocumentImpl) FindCapabilityDelegation(id DID) *VerificationMethod {
+	return d.CapabilityDelegation.FindByID(id)
+}
+
+// FindCapabilityInvocation finds a VerificationMethod by its ID
+func (d *DocumentImpl) FindCapabilityInvocation(id DID) *VerificationMethod {
+	return d.CapabilityInvocation.FindByID(id)
 }
 
 func (d *DocumentImpl) GetController(did DID) (DID, error) {

--- a/pkg/did/document_test.go
+++ b/pkg/did/document_test.go
@@ -148,6 +148,14 @@ func Test_Document(t *testing.T) {
 			assert.Len(t, doc.AssertionMethod, 1)
 			assert.Equal(t, doc.AssertionMethod[0].VerificationMethod, method)
 		})
+		t.Run("it adds the method to AssertionMethod once and Finds it", func(t *testing.T) {
+			doc := DocumentImpl{ID: *id123}
+			method := &VerificationMethod{ID: *id123Method}
+			doc.AddAssertionMethod(method)
+			vm := doc.FindAssertionMethod(*id123Method)
+			assert.NotNil(t, vm, "unable to find the method")
+			assert.Len(t, doc.AssertionMethod, 1)
+		})
 		t.Run("it adds the method to the verificationMethods once", func(t *testing.T) {
 			doc := DocumentImpl{ID: *id123}
 			method := &VerificationMethod{ID: *id123Method}
@@ -176,6 +184,14 @@ func Test_Document(t *testing.T) {
 			method := &VerificationMethod{ID: *id123Method}
 			doc.AddAuthenticationMethod(method)
 			doc.AddAuthenticationMethod(method)
+			assert.Len(t, doc.Authentication, 1)
+		})
+		t.Run("it adds the method to AuthenticationMethod once and Finds it", func(t *testing.T) {
+			doc := DocumentImpl{ID: *id123}
+			method := &VerificationMethod{ID: *id123Method}
+			doc.AddAuthenticationMethod(method)
+			vm := doc.FindAuthenticationMethod(*id123Method)
+			assert.NotNil(t, vm, "unable to find the method")
 			assert.Len(t, doc.Authentication, 1)
 		})
 		t.Run("it adds the method to the AuthenticationMethods once", func(t *testing.T) {
@@ -219,14 +235,30 @@ func Test_Document(t *testing.T) {
 			assert.Len(t, doc.CapabilityInvocation, 1)
 			assert.Len(t, doc.VerificationMethod, 1)
 		})
+		t.Run("it adds the method to CapabilityInvocation and Finds it", func(t *testing.T) {
+			doc := DocumentImpl{ID: *id123}
+			method := &VerificationMethod{ID: *id123Method}
+			doc.AddCapabilityInvocation(method)
+			vm := doc.FindCapabilityInvocation(*id123Method)
+			assert.NotNil(t, vm, "unable to find the method")
+			assert.Len(t, doc.VerificationMethod, 1)
+		})
 	})
 	t.Run("AddCapabilityDelegation", func(t *testing.T) {
 		t.Run("it adds the method to CapabilityDelegation once", func(t *testing.T) {
 			doc := DocumentImpl{ID: *id123}
 			method := &VerificationMethod{ID: *id123Method}
 			doc.AddCapabilityDelegation(method)
-			doc.AddCapabilityDelegation(method)
-			assert.Len(t, doc.CapabilityDelegation, 1)
+			vm := doc.FindCapabilityDelegation(*id123Method)
+			assert.NotNil(t, vm, "unable to find the method")
+			assert.Len(t, doc.VerificationMethod, 1)
+		})
+		t.Run("it adds the method to CapabilityInvocation and Finds it", func(t *testing.T) {
+			doc := DocumentImpl{ID: *id123}
+			method := &VerificationMethod{ID: *id123Method}
+			doc.AddCapabilityInvocation(method)
+			doc.AddCapabilityInvocation(method)
+			assert.Len(t, doc.CapabilityInvocation, 1)
 			assert.Len(t, doc.VerificationMethod, 1)
 		})
 	})

--- a/pkg/did/interface.go
+++ b/pkg/did/interface.go
@@ -44,4 +44,16 @@ type Document interface {
 	// EncryptJWE(id DID, buf []byte) (string, error)
 	// DecryptJWE(id DID, serial string) ([]byte, error)
 	GetController(id DID) (DID, error)
+
+	// FindAssertionMethod finds the first AssertionMethod with the given DID
+	FindAssertionMethod(id DID) *VerificationMethod
+
+	// FindAuthenticationMethod finds the first AuthenticationMethod with the given DID
+	FindAuthenticationMethod(id DID) *VerificationMethod
+
+	// FindCapabilityDelegation finds the first CapabilityDelegation with the given DID
+	FindCapabilityDelegation(id DID) *VerificationMethod
+
+	// FindCapabilityInvocation finds the first CapabilityInvocation with the given DID
+	FindCapabilityInvocation(id DID) *VerificationMethod
 }


### PR DESCRIPTION
It was necessary for us to have the DID Query methods in order to granularly search individual verification method types, in order to avoid interacting with the underlying struct.

## Changes

* `FindAssertionMethod()`
* `FindAuthenticationMethod()`
* `FindCapabilityDelegation()`
* `FindCapabilityInvocation()`

## Checklist

* [x] Unit tests
* [x] Documentation

## References *(optional)*

Fixes
Connects

<img width="10" height="9" src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" "> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples here.