### PR TITLE
Add Return Methods for DID List

### DIFF
--- a/pkg/did/document.go
+++ b/pkg/did/document.go
@@ -106,6 +106,26 @@ func (d *DocumentImpl) GetController(did DID) (DID, error) {
 	return DID{}, errors.New("did not found")
 }
 
+// GetAssertionMethods returns the list of assertion methods
+func (d *DocumentImpl) GetAssertionMethods() VerificationRelationships {
+	return d.AssertionMethod
+}
+
+// GetAuthenticationMethods returns the list of authentication methods
+func (d *DocumentImpl) GetAuthenticationMethods() VerificationRelationships {
+	return d.Authentication
+}
+
+// GetCapabilityDelegations returns the list of capability delegations
+func (d *DocumentImpl) GetCapabilityDelegations() VerificationRelationships {
+	return d.CapabilityDelegation
+}
+
+// GetCapabilityInvocations returns the list of capability invocations
+func (d *DocumentImpl) GetCapabilityInvocations() VerificationRelationships {
+	return d.CapabilityInvocation
+}
+
 func (d *DocumentImpl) GetID() DID {
 	return d.ID
 }
@@ -179,6 +199,11 @@ func (vms *VerificationMethods) Add(v *VerificationMethod) {
 }
 
 type VerificationRelationships []VerificationRelationship
+
+// Count returns the number of VerificationRelationships in the slice
+func (vmr VerificationRelationships) Count() int {
+	return len(vmr)
+}
 
 // FindByID returns the first VerificationRelationship that matches with the id.
 // For comparison both the ID of the embedded VerificationMethod and reference is used.

--- a/pkg/did/interface.go
+++ b/pkg/did/interface.go
@@ -31,6 +31,7 @@ type Document interface {
 	// AddAlias adds a string alias to the document for a .snr domain name into the AlsoKnownAs field
 	// in the document.
 	AddAlias(alias string)
+
 	AddController(id DID)
 
 	// ResolveEndpointURL finds the endpoint with the given type and unmarshalls it as single URL.
@@ -56,4 +57,16 @@ type Document interface {
 
 	// FindCapabilityInvocation finds the first CapabilityInvocation with the given DID
 	FindCapabilityInvocation(id DID) *VerificationMethod
+
+	// GetAssertionMethods returns all AssertionMethods
+	GetAssertionMethods() VerificationRelationships
+
+	// GetAuthenticationMethods returns all AuthenticationMethods
+	GetAuthenticationMethods() VerificationRelationships
+
+	// GetCapabilityDelegations returns all CapabilityDelegations
+	GetCapabilityDelegations() VerificationRelationships
+
+	// GetCapabilityInvocations returns all CapabilityInvocations
+	GetCapabilityInvocations() VerificationRelationships
 }


### PR DESCRIPTION
It was necessary for us to be able to interact with the underlying type for `VerificationRelationships`

## Changes

* `GetAssertionMethods()`
* `GetAuthenticationMethods()`
* `GetCapabilityDelegations()`
* `GetCapabilityInvocations()`

## Checklist

* [ ] Unit tests - *Not applicable*
* [x] Documentation

## References *(optional)*

Fixes
Connects

<img width="10" height="9" src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" "> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples here.