### PR TITLE
added registry model protos and cleaned up strucutre

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/sonr-io/sonr
 
 go 1.16
 
+replace (
+	./gen => ./gen/github.com/sonr-io/sonr
+	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+	google.golang.org/grpc => google.golang.org/grpc v1.33.2
+)
+
 require (
 	github.com/cosmos/cosmos-sdk v0.45.5
 	github.com/cosmos/ibc-go/v3 v3.0.0
@@ -60,7 +66,7 @@ require (
 	github.com/tendermint/tendermint v0.34.19
 	github.com/tendermint/tm-db v0.6.7
 	go.buf.build/grpc/go/sonr-io/blockchain v1.3.7
-	go.buf.build/grpc/go/sonr-io/motor v1.3.1
+	go.buf.build/grpc/go/sonr-io/motor v1.3.6
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/mobile v0.0.0-20220518205345-8578da9835fd
 	golang.org/x/net v0.0.0-20220524220425-1d687d428aca // indirect
@@ -71,9 +77,4 @@ require (
 	google.golang.org/grpc v1.46.2
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/yaml.v2 v2.4.0
-)
-
-replace (
-	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/sonr-io/sonr
 go 1.16
 
 replace (
-	./gen => ./gen/github.com/sonr-io/sonr
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2753,8 +2753,8 @@ go.buf.build/grpc/go/cosmos/gogo-proto v1.3.1 h1:movzgRYHiYXq/rd5Fo5KnMtYizbCKlv
 go.buf.build/grpc/go/cosmos/gogo-proto v1.3.1/go.mod h1:Oacq9kdGMFBOTGB/CrAMpHc7GwkJg1P1d0gKF6X0kuU=
 go.buf.build/grpc/go/sonr-io/blockchain v1.3.7 h1:XRr0pkZG12nbsWnvWfQggECwS4UwvBK4BNoYNioJ1fA=
 go.buf.build/grpc/go/sonr-io/blockchain v1.3.7/go.mod h1:kh09boSnQtZNONulz1c/8vPaa9ae4XkiYIANi/vNVks=
-go.buf.build/grpc/go/sonr-io/motor v1.3.1 h1:3Dxod9fjT6VmVhPWmgIDELKQVAWgK5iI3FURfxN4+5Y=
-go.buf.build/grpc/go/sonr-io/motor v1.3.1/go.mod h1:o8LpED3VyN9VeejYAK5tDQ6d2C3XdkmitACeEG1IsKc=
+go.buf.build/grpc/go/sonr-io/motor v1.3.6 h1:Om05PBU9yEBuzme11BbvlGGVOTjEtOE+vGrK5lR0qhg=
+go.buf.build/grpc/go/sonr-io/motor v1.3.6/go.mod h1:o8LpED3VyN9VeejYAK5tDQ6d2C3XdkmitACeEG1IsKc=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=

--- a/internal/motor/motor.go
+++ b/internal/motor/motor.go
@@ -1,128 +1,17 @@
 package motor
 
 import (
-	"errors"
-	"fmt"
+	"encoding/json"
 
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/sonr-io/sonr/pkg/client"
-	"github.com/sonr-io/sonr/pkg/crypto"
-	"github.com/sonr-io/sonr/pkg/did"
-	"github.com/sonr-io/sonr/pkg/tx"
-	"github.com/sonr-io/sonr/pkg/vault"
-	rt "github.com/sonr-io/sonr/x/registry/types"
+	"github.com/sonr-io/sonr/internal/motor/x/registry"
+	prt "go.buf.build/grpc/go/sonr-io/motor/registry/v1"
 )
 
-type MotorNode struct {
-	Cosmos  *client.Client
-	Wallet  *crypto.MPCWallet
-	Address string
-	PubKey  *secp256k1.PubKey
-	DIDDoc  did.Document
-	// Account *at.BaseAccount
-}
-
-func CreateAccount(password, dscPubKey []byte) (*MotorNode, error) {
-	m, err := setupDefault()
-	if err != nil {
+func CreateAccount(requestBytes []byte) (*registry.MotorNode, error) {
+	var request prt.CreateAccountRequest
+	if err := json.Unmarshal(requestBytes, &request); err != nil {
 		return nil, err
 	}
 
-	// create Vault shards to make sure this works before creating WhoIs
-	vc := vault.New()
-	deviceShard, sharedShard, recShard, unusedShards, err := m.Wallet.CreateInitialShards()
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: encrypt dscShard with dsc (i.e. webauthn)
-	dscShard := string(deviceShard)
-
-	// TODO: ecnrypt pskShard with psk (must be generated)
-	pskShard := string(sharedShard)
-
-	// password protect the recovery shard
-	pwShard, err := crypto.EncryptWithPassword(password, []byte(recShard))
-	if err != nil {
-		return nil, err
-	}
-
-	// create WhoIs
-	resp, err := createWhoIs(m)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Println(resp.String())
-
-	// create vault
-	vaultService, err := vc.CreateVault(
-		m.Address,
-		unusedShards,
-		string(dscPubKey),
-		dscShard,
-		pskShard,
-		pwShard,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// update DID Document
-	m.DIDDoc.AddService(vaultService)
-
-	// update whois
-	resp, err = updateWhoIs(m)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Println(resp.String())
-
-	return m, err
-}
-
-func createWhoIs(m *MotorNode) (*sdk.TxResponse, error) {
-	docBz, err := m.DIDDoc.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-
-	msg1 := rt.NewMsgCreateWhoIs(m.Address, m.PubKey, docBz, rt.WhoIsType_USER)
-	txRaw, err := tx.SignTxWithWallet(m.Wallet, "/sonrio.sonr.registry.MsgCreateWhoIs", msg1)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := m.Cosmos.BroadcastTx(txRaw)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.TxResponse.RawLog != "[]" {
-		return nil, errors.New(resp.TxResponse.RawLog)
-	}
-	return resp.TxResponse, nil
-}
-
-func updateWhoIs(m *MotorNode) (*sdk.TxResponse, error) {
-	docBz, err := m.DIDDoc.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-
-	msg1 := rt.NewMsgUpdateWhoIs(m.Address, docBz)
-	txRaw, err := tx.SignTxWithWallet(m.Wallet, "/sonrio.sonr.registry.MsgUpdateWhoIs", msg1)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := m.Cosmos.BroadcastTx(txRaw)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.TxResponse.RawLog != "[]" {
-		return nil, errors.New(resp.TxResponse.RawLog)
-	}
-	return resp.TxResponse, nil
+	return registry.CreateAccount(request)
 }

--- a/internal/motor/motor_test.go
+++ b/internal/motor/motor_test.go
@@ -1,42 +1,21 @@
 package motor
 
 import (
+	"encoding/json"
 	"testing"
 
-	"github.com/sonr-io/sonr/pkg/did"
-	"github.com/sonr-io/sonr/pkg/did/ssi"
-	"github.com/sonr-io/sonr/x/registry/types"
 	"github.com/stretchr/testify/assert"
+	prt "go.buf.build/grpc/go/sonr-io/motor/registry/v1"
 )
 
 func Test_CreateAccount(t *testing.T) {
-	_, err := CreateAccount(
-		[]byte("mystrongpassword"),
-		[]byte("somerandomdscpubkey"),
-	)
-	assert.NoError(t, err, "wallet generation succeeds")
-}
-
-func Test_DocumentSerialization(t *testing.T) {
-	m, err := setupDefault()
-	assert.NoError(t, err, "setup succeeds")
-
-	m.DIDDoc.AddService(did.Service{
-		ID:   ssi.MustParseURI("https://vault.sonr.ws"),
-		Type: "vault",
-		ServiceEndpoint: map[string]string{
-			"cid": "asdfoasdfklasdjfashfk",
-		},
+	req, err := json.Marshal(prt.CreateAccountRequest{
+		Password:          "password",
+		EcdsaDscKey:       []byte("somerandomdscpubkey"),
+		EcdsaPresharedKey: []byte("somerandompskpubkey"),
 	})
-	marshalled, err := m.DIDDoc.MarshalJSON()
-	assert.NoError(t, err, "marshals")
+	assert.NoError(t, err, "create account request marshals")
 
-	des := did.BlankDocument()
-	err = des.UnmarshalJSON(marshalled)
-	assert.NoError(t, err, "unmarshals")
-
-	regDes, err := types.NewDIDDocumentFromPkg(des)
-	assert.NoError(t, err, "converts")
-
-	assert.Equal(t, len(m.DIDDoc.GetServices()), len(regDes.Service))
+	_, err = CreateAccount(req)
+	assert.NoError(t, err, "wallet generation succeeds")
 }

--- a/internal/motor/proto/buf.lock
+++ b/internal/motor/proto/buf.lock
@@ -8,7 +8,7 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
-    commit: d71cd4e301d64db39d6b63f27a45f2cc
+    commit: 5463f864d90d42678e5622499c08548a
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
@@ -16,4 +16,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 8ab0a452adb64b36ac7a40ae95bd59b2
+    commit: 86d30bdfc34044fb9339e1bd9673839b

--- a/internal/motor/proto/registry/v1/account.proto
+++ b/internal/motor/proto/registry/v1/account.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package sonrio.motor.registry.v1;
+option go_package = "github.com/sonr-io/sonr/motor/types/registry";
+
+// CreateAccount Request contains the three keys needed to create an account on Sonr
+message CreateAccountRequest {
+  string password = 1;
+  bytes ecdsa_dsc_key = 2;
+  bytes ecdsa_preshared_key = 3;
+}
+
+message CreateAccountResponse {
+  bytes psk = 1;
+  string address = 2;
+}

--- a/internal/motor/x/registry/config.go
+++ b/internal/motor/x/registry/config.go
@@ -1,4 +1,4 @@
-package motor
+package registry
 
 import (
 	"github.com/sonr-io/sonr/pkg/client"

--- a/internal/motor/x/registry/create_account.go
+++ b/internal/motor/x/registry/create_account.go
@@ -1,0 +1,129 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sonr-io/sonr/pkg/client"
+	"github.com/sonr-io/sonr/pkg/crypto"
+	"github.com/sonr-io/sonr/pkg/did"
+	"github.com/sonr-io/sonr/pkg/tx"
+	"github.com/sonr-io/sonr/pkg/vault"
+	rt "github.com/sonr-io/sonr/x/registry/types"
+	registry "go.buf.build/grpc/go/sonr-io/motor/registry/v1"
+)
+
+type MotorNode struct {
+	Cosmos  *client.Client
+	Wallet  *crypto.MPCWallet
+	Address string
+	PubKey  *secp256k1.PubKey
+	DIDDoc  did.Document
+	// Account *at.BaseAccount
+}
+
+func CreateAccount(request registry.CreateAccountRequest) (*MotorNode, error) {
+	m, err := setupDefault()
+	if err != nil {
+		return nil, err
+	}
+
+	// create Vault shards to make sure this works before creating WhoIs
+	vc := vault.New()
+	deviceShard, sharedShard, recShard, unusedShards, err := m.Wallet.CreateInitialShards()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: encrypt dscShard with dsc (i.e. webauthn)
+	dscShard := string(deviceShard)
+
+	// TODO: ecnrypt pskShard with psk (must be generated)
+	pskShard := string(sharedShard)
+
+	// password protect the recovery shard
+	pwShard, err := crypto.EncryptWithPassword(request.Password, []byte(recShard))
+	if err != nil {
+		return nil, err
+	}
+
+	// create WhoIs
+	resp, err := createWhoIs(m)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println(resp.String())
+
+	// create vault
+	vaultService, err := vc.CreateVault(
+		m.Address,
+		unusedShards,
+		string(request.EcdsaDscKey),
+		dscShard,
+		pskShard,
+		pwShard,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// update DID Document
+	m.DIDDoc.AddService(vaultService)
+
+	// update whois
+	resp, err = updateWhoIs(m)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println(resp.String())
+
+	return m, err
+}
+
+func createWhoIs(m *MotorNode) (*sdk.TxResponse, error) {
+	docBz, err := m.DIDDoc.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	msg1 := rt.NewMsgCreateWhoIs(m.Address, m.PubKey, docBz, rt.WhoIsType_USER)
+	txRaw, err := tx.SignTxWithWallet(m.Wallet, "/sonrio.sonr.registry.MsgCreateWhoIs", msg1)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := m.Cosmos.BroadcastTx(txRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.TxResponse.RawLog != "[]" {
+		return nil, errors.New(resp.TxResponse.RawLog)
+	}
+	return resp.TxResponse, nil
+}
+
+func updateWhoIs(m *MotorNode) (*sdk.TxResponse, error) {
+	docBz, err := m.DIDDoc.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	msg1 := rt.NewMsgUpdateWhoIs(m.Address, docBz)
+	txRaw, err := tx.SignTxWithWallet(m.Wallet, "/sonrio.sonr.registry.MsgUpdateWhoIs", msg1)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := m.Cosmos.BroadcastTx(txRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.TxResponse.RawLog != "[]" {
+		return nil, errors.New(resp.TxResponse.RawLog)
+	}
+	return resp.TxResponse, nil
+}

--- a/pkg/crypto/password.go
+++ b/pkg/crypto/password.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/crypto/scrypt"
 )
 
-func EncryptWithPassword(password, plaintext []byte) (string, error) {
+func EncryptWithPassword(password string, plaintext []byte) (string, error) {
 	key, err := deriveKey(password)
 	if err != nil {
 		return "", err
@@ -34,7 +34,7 @@ func EncryptWithPassword(password, plaintext []byte) (string, error) {
 	return string(ciphertext), nil
 }
 
-func DecryptWithPassword(password, ciphertext []byte) (string, error) {
+func DecryptWithPassword(password string, ciphertext []byte) (string, error) {
 	key, err := deriveKey(password)
 	if err != nil {
 		return "", err
@@ -60,9 +60,9 @@ func DecryptWithPassword(password, ciphertext []byte) (string, error) {
 	return string(plaintext), nil
 }
 
-func deriveKey(password []byte) ([]byte, error) {
+func deriveKey(password string) ([]byte, error) {
 	// including a salt would make it impossible to reliably login from other devices
-	key, err := scrypt.Key(password, []byte(""), 1<<20, 8, 1, 32)
+	key, err := scrypt.Key([]byte(password), []byte(""), 1<<20, 8, 1, 32)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crypto/password_test.go
+++ b/pkg/crypto/password_test.go
@@ -8,20 +8,20 @@ import (
 
 func Test_EncryptWithPassword(t *testing.T) {
 	t.Run("encrypts and decrypts successfully", func(t *testing.T) {
-		ciphertext, err := EncryptWithPassword([]byte("password"), []byte("mycontent"))
+		ciphertext, err := EncryptWithPassword("password", []byte("mycontent"))
 		assert.NoError(t, err, "encryption succeeds")
 
-		plaintext, err := DecryptWithPassword([]byte("password"), []byte(ciphertext))
+		plaintext, err := DecryptWithPassword("password", []byte(ciphertext))
 		assert.NoError(t, err, "decryption succeeds")
 
 		assert.Equal(t, "mycontent", string(plaintext), "plaintext matches")
 	})
 
 	t.Run("fails to decrypt with wrong password", func(t *testing.T) {
-		ciphertext, err := EncryptWithPassword([]byte("password"), []byte("mycontent"))
+		ciphertext, err := EncryptWithPassword("password", []byte("mycontent"))
 		assert.NoError(t, err, "encryption succeeds")
 
-		_, err = DecryptWithPassword([]byte("wrongpassword"), []byte(ciphertext))
+		_, err = DecryptWithPassword("wrongpassword", []byte(ciphertext))
 		assert.ErrorContains(t, err, "cipher: message authentication failed", "decryption fails")
 	})
 }


### PR DESCRIPTION
Add protos for motor's `CreateAccount` method.

This PR refactors `CreateAccount` such that it uses a proto-defined message as an argument. This will make it easier to standardize parameters across platforms and also make serialization easy.

## Changes

- Added `CreateAccountRequest` proto
  - Request is expected to be json serialized
- Moved business logic into a registry package in order to make the motor package more scalable.
  - Sibling packages can be added to mirror this
  - The root-level motor package need only deserialize the request and pass it to the appropriate package

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>