### PR TITLE
Security: Strictly parse integers

### DIFF
--- a/x/bucket/client/cli/tx_where_is.go
+++ b/x/bucket/client/cli/tx_where_is.go
@@ -27,10 +27,11 @@ func CmdCreateWhereIs() *cobra.Command {
 				return errors.New("label must be defined")
 			}
 
-			roleConv, err := strconv.Atoi(args[1])
+			// parse strictly
+			roleConv, err := strconv.ParseUint(args[1], 10, 32)
 			role := types.BucketRole(roleConv)
 
-			visiblityConv, err := strconv.Atoi(args[2])
+			visiblityConv, err := strconv.ParseUint(args[2], 10, 32)
 			visilbity := types.BucketVisibility(visiblityConv)
 
 			msg := types.NewMsgCreateWhereIs(clientCtx.GetFromAddress().String(), args[0], role, visilbity, nil)


### PR DESCRIPTION
Atoi will silently trim bits, and the error is never checked. Ideally we should not silently drop bits, and we should validate the errors.


## Changes

explicitly parse UInts with 32 bits instead of relying on automatic, untyped parsing.


Fixes:
#533 
#534 