### PR TITLE
Fix label for tar.gz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,15 @@ bind.android:
 bind.ios:
 	TAR_COMPRESS=false && sh $(SCRIPTS_DIR)/bind.sh -i
 
-## └─ web           - iOS Framework
+## └─ web           - WASM Framework
 bind.web:
 	TAR_COMPRESS=false && sh $(SCRIPTS_DIR)/bind.sh -w
+
+## └─ tar           - Build All & Tar Compress
+bind.tar:
+	TAR_COMPRESS=true && sh $(SCRIPTS_DIR)/bind.sh -a
+	TAR_COMPRESS=true && sh $(SCRIPTS_DIR)/bind.sh -i
+	TAR_COMPRESS=true && sh $(SCRIPTS_DIR)/bind.sh -w
 
 ## proto       :   Compiles Go Proto Files and pushes to Buf.Build
 proto: proto.go proto.buf

--- a/scripts/bind.sh
+++ b/scripts/bind.sh
@@ -23,7 +23,7 @@ while getopts "iawm" opt; do
 
       if [ "$TAR_COMPRESS" = true ] ; then
         echo "🔷 Compressing Android Artifact..."
-        tar -czf ${BUILDDIR}/io.sonr.motor-android-${VERSION}.tar.gz io.sonr.motor.aar
+        tar -czf ${BUILDDIR}/motor-${VERSION}-android.tar.gz io.sonr.motor.aar
         rm -rf ${ANDROID_ARTIFACT}
         echo "✅ Android Tarball written to: ${ANDROID_TAR_BALL}"
       fi
@@ -37,7 +37,7 @@ while getopts "iawm" opt; do
 
       if [ "$TAR_COMPRESS" = true ] ; then
         echo "🔷 Compressing iOS Artifact..."
-        tar -czf ${BUILDDIR}/io.sonr.motor-ios-${VERSION}.tar.gz Motor.xcframework
+        tar -czf ${BUILDDIR}/motor-${VERSION}-ios.tar.gz Motor.xcframework
         rm -rf ${IOS_ARTIFACT}
         echo "✅ iOS Tarball written to: ${IOS_TAR_BALL}"
       fi


### PR DESCRIPTION
iOS and Android targets have incorrect label for tar.gz in build script breaking the download script in motor-flutter

Fixes
Connects

<img width="10" height="9" src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" "> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples here.