### PR TITLE
Add repository dispatch for motor cocoapods

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,13 +95,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAR_COMPRESS: true
-  #     # - name: motor-ios Repository Dispatch
-  #     #   uses: peter-evans/repository-dispatch@v2
-  #     #   with:
-  #     #     token: ${{ secrets.ACTIONS_GH_TOKEN }}
-  #     #     repository: sonr-io/motor-ios
-  #     #     event-type: new-ios-framework
-  #     #     client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+      - name: motor-ios Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.ACTIONS_GH_TOKEN }}
+          repository: sonr-io/motor_pod
+          event-type: new-ios-framework
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
 
   ## ------------------------------------------------------------
   ## [MOTOR] Build and release for Android


### PR DESCRIPTION
Add repository Dispatch to CI/CD to trigger cocoapods deployment in https://github.com/sonr-io/motor_pod

Fixes
Connects

<img width="10" height="9" src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" "> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples here.