### PR TITLE
Fix GitHub links in CONTRIBUTING.md

### DIFF
--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -36,11 +36,11 @@ to <team@sonr.io>.
 
 > If you want to ask a question, we assume that you have read the available [Documentation](https://docs.sonr.io).
 
-Before you ask a question, it is best to search for existing [Issues](https://gitub.com/sonr-io/sonr/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/sonr-io/sonr/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [Issue](https://gitub.com/sonr-io/sonr/issues/new).
+- Open an [Issue](https://github.com/sonr-io/sonr/issues/new).
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
 
@@ -75,7 +75,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://docs.sonr.io). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://gitub.com/sonr-io/sonrissues?q=label%3Abug).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/sonr-io/sonrissues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)
@@ -92,7 +92,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](https://gitub.com/sonr-io/sonr/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open an [Issue](https://github.com/sonr-io/sonr/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
@@ -115,13 +115,13 @@ This section guides you through submitting an enhancement suggestion for Sonr, *
 
 - Make sure that you are using the latest version.
 - Read the [documentation](https://docs.sonr.io) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a [search](https://gitub.com/sonr-io/sonr/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Perform a [search](https://github.com/sonr-io/sonr/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 <!-- omit in toc -->
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://gitub.com/sonr-io/sonr/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/sonr-io/sonr/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
@@ -132,8 +132,8 @@ Enhancement suggestions are tracked as [GitHub issues](https://gitub.com/sonr-io
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
 
 ### Your First Code Contribution
-1. [Find an issue](https://gitub.com/sonr-io/sonr/issues) that you are interested in addressing or a feature that you would like to add.
-2. [Fork the repository](https://gitub.com/sonr-io/sonr/fork) to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
+1. [Find an issue](https://github.com/sonr-io/sonr/issues) that you are interested in addressing or a feature that you would like to add.
+2. [Fork the repository](https://github.com/sonr-io/sonr/fork) to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
 3. [Setup the development environment](../../README.md#installing) on your local machine.
 4. [Create a new branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/) for your fix or feature.
 5. Submit a [pull request](https://help.github.com/articles/about-pull-requests/) with your changes.


### PR DESCRIPTION
Fix GitHub links in CONTRIBUTING.md

## Changes

* Replace 'gitub' with 'github' in URLs

## API Updates

None

### New Features

N/A, this does not change the functionality

### Deprecations

None

## Checklist

* [x] Unit tests
* [x] Documentation

Fixes URLs