### PR TITLE
Fix the Public Key from resulting MPC Wallet not getting stored into DIDDocument

### DIFF
--- a/pkg/did/document.go
+++ b/pkg/did/document.go
@@ -517,6 +517,24 @@ func NewVerificationMethod(id DID, keyType ssi.KeyType, controller DID, key cryp
 	return vm, nil
 }
 
+// NewVerificationMethod is a convenience method to easily create verificationMethods based on a set of given params.
+// It automatically encodes the provided public key based on the keyType.
+func NewVerificationMethodFromBytes(id DID, keyType ssi.KeyType, controller DID, key []byte) (*VerificationMethod, error) {
+
+	if keyType == ssi.JsonWebKey2020 {
+		return nil, errors.New("JWK is not implemented for NewVerificationMethodFromBytes")
+	}
+	encodedKey := base58.Encode(key, base58.BitcoinAlphabet)
+	vm := &VerificationMethod{
+		ID:              id,
+		Type:            keyType,
+		Controller:      controller,
+		PublicKeyBase58: encodedKey,
+	}
+
+	return vm, nil
+}
+
 // VerificationRelationship represents the usage of a VerificationMethod e.g. in authentication, assertionMethod, or keyAgreement.
 type VerificationRelationship struct {
 	*VerificationMethod


### PR DESCRIPTION
The `CreateAccount` method present in `pkg/motor` was not adding the public key of the MPC wallet as a controller and assertionMethod of the DIDDocument. This is required for WebAuthN based authentication **without needing the Motor node**.

## Changes

* Create `NewVerificationFromBytes`
* Implement `AddVerificationMethod` to the CreateAccount method.

## API Updates

**N/A**

## Checklist

* [x] Unit tests
* [x] Documentation

## References *(optional)*

Fixes
Connects

<img width="10" height="9" src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" "> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples here.