### PR TITLE
Add RegistryKeeper as expected type for schema and bucket

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -412,18 +412,6 @@ func New(
 	)
 	monitoringModule := monitoringp.NewAppModule(appCodec, app.MonitoringKeeper)
 
-	app.SchemaKeeper = *schemamodulekeeper.NewKeeper(
-		appCodec,
-		keys[schemamoduletypes.StoreKey],
-		keys[schemamoduletypes.MemStoreKey],
-		app.GetSubspace(schemamoduletypes.ModuleName),
-
-		app.AccountKeeper,
-		app.CapabilityKeeper,
-		app.BankKeeper,
-	)
-	schemaModule := schemamodule.NewAppModule(appCodec, app.SchemaKeeper, app.AccountKeeper, app.BankKeeper)
-
 	app.RegistryKeeper = *registrymodulekeeper.NewKeeper(
 		appCodec,
 		keys[registrymoduletypes.StoreKey],
@@ -434,6 +422,19 @@ func New(
 	)
 	registryModule := registrymodule.NewAppModule(appCodec, app.RegistryKeeper, app.AccountKeeper, app.BankKeeper)
 
+	app.SchemaKeeper = *schemamodulekeeper.NewKeeper(
+		appCodec,
+		keys[schemamoduletypes.StoreKey],
+		keys[schemamoduletypes.MemStoreKey],
+		app.GetSubspace(schemamoduletypes.ModuleName),
+
+		app.AccountKeeper,
+		app.CapabilityKeeper,
+		app.BankKeeper,
+		app.RegistryKeeper,
+	)
+	schemaModule := schemamodule.NewAppModule(appCodec, app.SchemaKeeper, app.AccountKeeper, app.BankKeeper)
+
 	app.BucketKeeper = *bucketmodulekeeper.NewKeeper(
 		appCodec,
 		keys[bucketmoduletypes.StoreKey],
@@ -441,6 +442,7 @@ func New(
 		app.GetSubspace(bucketmoduletypes.ModuleName),
 
 		app.BankKeeper,
+		app.RegistryKeeper,
 	)
 	bucketModule := bucketmodule.NewAppModule(appCodec, app.BucketKeeper, app.AccountKeeper, app.BankKeeper)
 

--- a/docs/static/blockchain.yaml
+++ b/docs/static/blockchain.yaml
@@ -31657,15 +31657,48 @@ paths:
                       properties:
                         did:
                           type: string
-                          title: the DID for this schema
+                          title: >-
+                            the DID for this schema should not be populated by
+                            request
+                        creator:
+                          type: string
                         label:
                           type: string
                           title: an alternative reference point
-                        cid:
-                          type: string
-                          description: >-
-                            a reference to information stored within an IPFS
-                            node.
+                        fields:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              field:
+                                title: Type of a single schema property
+                                type: string
+                                enum:
+                                  - LIST
+                                  - BOOL
+                                  - INT
+                                  - FLOAT
+                                  - STRING
+                                  - BYTES
+                                  - LINK
+                                  - ANY
+                                default: LIST
+                              link_kind:
+                                title: >-
+                                  Optional field for a link context if
+                                  `SchemaKind` is of type `Link`
+                                type: string
+                                enum:
+                                  - UNKNOWN
+                                  - OBJECT
+                                  - SCHEMA
+                                  - BUCKET
+                                default: UNKNOWN
+                              link:
+                                type: string
+                          title: the properties of this schema
                     creator:
                       type: string
                       title: Creator is the DID of the creator
@@ -31777,16 +31810,6 @@ paths:
           in: query
           required: false
           type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
-          in: query
-          required: false
-          type: boolean
       tags:
         - Query
   /sonr-io/sonr/schema/query/schema:
@@ -31805,9 +31828,7 @@ paths:
                 properties:
                   did:
                     type: string
-                    title: |-
-                      Represents the types of fields a schema can have
-                      the DID for this schema
+                    title: the DID for this schema should not be populated by request
                   creator:
                     type: string
                   label:
@@ -31898,13 +31919,48 @@ paths:
                     properties:
                       did:
                         type: string
-                        title: the DID for this schema
+                        title: >-
+                          the DID for this schema should not be populated by
+                          request
+                      creator:
+                        type: string
                       label:
                         type: string
                         title: an alternative reference point
-                      cid:
-                        type: string
-                        description: a reference to information stored within an IPFS node.
+                      fields:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            field:
+                              title: Type of a single schema property
+                              type: string
+                              enum:
+                                - LIST
+                                - BOOL
+                                - INT
+                                - FLOAT
+                                - STRING
+                                - BYTES
+                                - LINK
+                                - ANY
+                              default: LIST
+                            link_kind:
+                              title: >-
+                                Optional field for a link context if
+                                `SchemaKind` is of type `Link`
+                              type: string
+                              enum:
+                                - UNKNOWN
+                                - OBJECT
+                                - SCHEMA
+                                - BUCKET
+                              default: UNKNOWN
+                            link:
+                              type: string
+                        title: the properties of this schema
                   creator:
                     type: string
                     title: Creator is the DID of the creator
@@ -31978,15 +32034,48 @@ paths:
                       properties:
                         did:
                           type: string
-                          title: the DID for this schema
+                          title: >-
+                            the DID for this schema should not be populated by
+                            request
+                        creator:
+                          type: string
                         label:
                           type: string
                           title: an alternative reference point
-                        cid:
-                          type: string
-                          description: >-
-                            a reference to information stored within an IPFS
-                            node.
+                        fields:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              field:
+                                title: Type of a single schema property
+                                type: string
+                                enum:
+                                  - LIST
+                                  - BOOL
+                                  - INT
+                                  - FLOAT
+                                  - STRING
+                                  - BYTES
+                                  - LINK
+                                  - ANY
+                                default: LIST
+                              link_kind:
+                                title: >-
+                                  Optional field for a link context if
+                                  `SchemaKind` is of type `Link`
+                                type: string
+                                enum:
+                                  - UNKNOWN
+                                  - OBJECT
+                                  - SCHEMA
+                                  - BUCKET
+                                default: UNKNOWN
+                              link:
+                                type: string
+                          title: the properties of this schema
                     creator:
                       type: string
                       title: Creator is the DID of the creator
@@ -32077,20 +32166,11 @@ paths:
           in: query
           required: false
           type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
-          in: query
-          required: false
-          type: boolean
       tags:
         - Query
   '/sonr-io/sonr/schema/query/what_is/{did}':
     get:
+      summary: Queries a whatis by did
       operationId: SonrioSonrSchemaWhatIsByDid
       responses:
         '200':
@@ -32110,13 +32190,48 @@ paths:
                     properties:
                       did:
                         type: string
-                        title: the DID for this schema
+                        title: >-
+                          the DID for this schema should not be populated by
+                          request
+                      creator:
+                        type: string
                       label:
                         type: string
                         title: an alternative reference point
-                      cid:
-                        type: string
-                        description: a reference to information stored within an IPFS node.
+                      fields:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            field:
+                              title: Type of a single schema property
+                              type: string
+                              enum:
+                                - LIST
+                                - BOOL
+                                - INT
+                                - FLOAT
+                                - STRING
+                                - BYTES
+                                - LINK
+                                - ANY
+                              default: LIST
+                            link_kind:
+                              title: >-
+                                Optional field for a link context if
+                                `SchemaKind` is of type `Link`
+                              type: string
+                              enum:
+                                - UNKNOWN
+                                - OBJECT
+                                - SCHEMA
+                                - BUCKET
+                              default: UNKNOWN
+                            link:
+                              type: string
+                        title: the properties of this schema
                   creator:
                     type: string
                     title: Creator is the DID of the creator
@@ -32202,16 +32317,6 @@ paths:
             when key
 
             is set.
-          in: query
-          required: false
-          type: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
           in: query
           required: false
           type: boolean
@@ -56501,13 +56606,46 @@ definitions:
             properties:
               did:
                 type: string
-                title: the DID for this schema
+                title: the DID for this schema should not be populated by request
+              creator:
+                type: string
               label:
                 type: string
                 title: an alternative reference point
-              cid:
-                type: string
-                description: a reference to information stored within an IPFS node.
+              fields:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    field:
+                      title: Type of a single schema property
+                      type: string
+                      enum:
+                        - LIST
+                        - BOOL
+                        - INT
+                        - FLOAT
+                        - STRING
+                        - BYTES
+                        - LINK
+                        - ANY
+                      default: LIST
+                    link_kind:
+                      title: >-
+                        Optional field for a link context if `SchemaKind` is of
+                        type `Link`
+                      type: string
+                      enum:
+                        - UNKNOWN
+                        - OBJECT
+                        - SCHEMA
+                        - BUCKET
+                      default: UNKNOWN
+                    link:
+                      type: string
+                title: the properties of this schema
           creator:
             type: string
             title: Creator is the DID of the creator
@@ -56554,13 +56692,46 @@ definitions:
               properties:
                 did:
                   type: string
-                  title: the DID for this schema
+                  title: the DID for this schema should not be populated by request
+                creator:
+                  type: string
                 label:
                   type: string
                   title: an alternative reference point
-                cid:
-                  type: string
-                  description: a reference to information stored within an IPFS node.
+                fields:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      field:
+                        title: Type of a single schema property
+                        type: string
+                        enum:
+                          - LIST
+                          - BOOL
+                          - INT
+                          - FLOAT
+                          - STRING
+                          - BYTES
+                          - LINK
+                          - ANY
+                        default: LIST
+                      link_kind:
+                        title: >-
+                          Optional field for a link context if `SchemaKind` is
+                          of type `Link`
+                        type: string
+                        enum:
+                          - UNKNOWN
+                          - OBJECT
+                          - SCHEMA
+                          - BUCKET
+                        default: UNKNOWN
+                      link:
+                        type: string
+                  title: the properties of this schema
             creator:
               type: string
               title: Creator is the DID of the creator
@@ -56619,9 +56790,7 @@ definitions:
         properties:
           did:
             type: string
-            title: |-
-              Represents the types of fields a schema can have
-              the DID for this schema
+            title: the DID for this schema should not be populated by request
           creator:
             type: string
           label:
@@ -56676,13 +56845,46 @@ definitions:
             properties:
               did:
                 type: string
-                title: the DID for this schema
+                title: the DID for this schema should not be populated by request
+              creator:
+                type: string
               label:
                 type: string
                 title: an alternative reference point
-              cid:
-                type: string
-                description: a reference to information stored within an IPFS node.
+              fields:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    field:
+                      title: Type of a single schema property
+                      type: string
+                      enum:
+                        - LIST
+                        - BOOL
+                        - INT
+                        - FLOAT
+                        - STRING
+                        - BYTES
+                        - LINK
+                        - ANY
+                      default: LIST
+                    link_kind:
+                      title: >-
+                        Optional field for a link context if `SchemaKind` is of
+                        type `Link`
+                      type: string
+                      enum:
+                        - UNKNOWN
+                        - OBJECT
+                        - SCHEMA
+                        - BUCKET
+                      default: UNKNOWN
+                    link:
+                      type: string
+                title: the properties of this schema
           creator:
             type: string
             title: Creator is the DID of the creator
@@ -56717,13 +56919,46 @@ definitions:
               properties:
                 did:
                   type: string
-                  title: the DID for this schema
+                  title: the DID for this schema should not be populated by request
+                creator:
+                  type: string
                 label:
                   type: string
                   title: an alternative reference point
-                cid:
-                  type: string
-                  description: a reference to information stored within an IPFS node.
+                fields:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      field:
+                        title: Type of a single schema property
+                        type: string
+                        enum:
+                          - LIST
+                          - BOOL
+                          - INT
+                          - FLOAT
+                          - STRING
+                          - BYTES
+                          - LINK
+                          - ANY
+                        default: LIST
+                      link_kind:
+                        title: >-
+                          Optional field for a link context if `SchemaKind` is
+                          of type `Link`
+                        type: string
+                        enum:
+                          - UNKNOWN
+                          - OBJECT
+                          - SCHEMA
+                          - BUCKET
+                        default: UNKNOWN
+                      link:
+                        type: string
+                  title: the properties of this schema
             creator:
               type: string
               title: Creator is the DID of the creator
@@ -56757,13 +56992,46 @@ definitions:
             properties:
               did:
                 type: string
-                title: the DID for this schema
+                title: the DID for this schema should not be populated by request
+              creator:
+                type: string
               label:
                 type: string
                 title: an alternative reference point
-              cid:
-                type: string
-                description: a reference to information stored within an IPFS node.
+              fields:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    field:
+                      title: Type of a single schema property
+                      type: string
+                      enum:
+                        - LIST
+                        - BOOL
+                        - INT
+                        - FLOAT
+                        - STRING
+                        - BYTES
+                        - LINK
+                        - ANY
+                      default: LIST
+                    link_kind:
+                      title: >-
+                        Optional field for a link context if `SchemaKind` is of
+                        type `Link`
+                      type: string
+                      enum:
+                        - UNKNOWN
+                        - OBJECT
+                        - SCHEMA
+                        - BUCKET
+                      default: UNKNOWN
+                    link:
+                      type: string
+                title: the properties of this schema
           creator:
             type: string
             title: Creator is the DID of the creator
@@ -56787,9 +57055,7 @@ definitions:
     properties:
       did:
         type: string
-        title: |-
-          Represents the types of fields a schema can have
-          the DID for this schema
+        title: the DID for this schema should not be populated by request
       creator:
         type: string
       label:
@@ -56870,19 +57136,6 @@ definitions:
         default: UNKNOWN
       link:
         type: string
-  sonrio.sonr.schema.SchemaReference:
-    type: object
-    properties:
-      did:
-        type: string
-        title: the DID for this schema
-      label:
-        type: string
-        title: an alternative reference point
-      cid:
-        type: string
-        description: a reference to information stored within an IPFS node.
-    title: Schema defines the shapes of schemas on Sonr
   sonrio.sonr.schema.WhatIs:
     type: object
     properties:
@@ -56895,13 +57148,46 @@ definitions:
         properties:
           did:
             type: string
-            title: the DID for this schema
+            title: the DID for this schema should not be populated by request
+          creator:
+            type: string
           label:
             type: string
             title: an alternative reference point
-          cid:
-            type: string
-            description: a reference to information stored within an IPFS node.
+          fields:
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                field:
+                  title: Type of a single schema property
+                  type: string
+                  enum:
+                    - LIST
+                    - BOOL
+                    - INT
+                    - FLOAT
+                    - STRING
+                    - BYTES
+                    - LINK
+                    - ANY
+                  default: LIST
+                link_kind:
+                  title: >-
+                    Optional field for a link context if `SchemaKind` is of type
+                    `Link`
+                  type: string
+                  enum:
+                    - UNKNOWN
+                    - OBJECT
+                    - SCHEMA
+                    - BUCKET
+                  default: UNKNOWN
+                link:
+                  type: string
+            title: the properties of this schema
       creator:
         type: string
         title: Creator is the DID of the creator

--- a/testutil/keeper/bucket.go
+++ b/testutil/keeper/bucket.go
@@ -42,6 +42,7 @@ func BucketKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 		memStoreKey,
 		paramsSubspace,
 		nil,
+		nil,
 	)
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())

--- a/testutil/keeper/schema.go
+++ b/testutil/keeper/schema.go
@@ -47,6 +47,7 @@ func SchemaKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())

--- a/x/bucket/keeper/keeper.go
+++ b/x/bucket/keeper/keeper.go
@@ -18,7 +18,8 @@ type (
 		memKey     sdk.StoreKey
 		paramstore paramtypes.Subspace
 
-		bankKeeper types.BankKeeper
+		bankKeeper     types.BankKeeper
+		registryKeeper types.RegistryKeeper
 	}
 )
 
@@ -29,6 +30,7 @@ func NewKeeper(
 	ps paramtypes.Subspace,
 
 	bankKeeper types.BankKeeper,
+	registryKeeper types.RegistryKeeper,
 ) *Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
@@ -37,11 +39,12 @@ func NewKeeper(
 
 	return &Keeper{
 
-		cdc:        cdc,
-		storeKey:   storeKey,
-		memKey:     memKey,
-		paramstore: ps,
-		bankKeeper: bankKeeper,
+		cdc:            cdc,
+		storeKey:       storeKey,
+		memKey:         memKey,
+		paramstore:     ps,
+		bankKeeper:     bankKeeper,
+		registryKeeper: registryKeeper,
 	}
 }
 

--- a/x/bucket/types/expected_keepers.go
+++ b/x/bucket/types/expected_keepers.go
@@ -3,6 +3,7 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	rt "github.com/sonr-io/sonr/x/registry/types"
 )
 
 // AccountKeeper defines the expected account keeper used for simulations (noalias)
@@ -14,5 +15,13 @@ type AccountKeeper interface {
 // BankKeeper defines the expected interface needed to retrieve account balances.
 type BankKeeper interface {
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	// Methods imported from bank should be defined here
+}
+
+// RegistryKeeper defines the expected interface needed to manage account did documents.
+type RegistryKeeper interface {
+	GetWhoIs(ctx sdk.Context, id string) (val rt.WhoIs, found bool)
+	FindWhoIsByAlias(ctx sdk.Context, alias string) (val rt.WhoIs, found bool)
+	GetWhoIsFromOwner(ctx sdk.Context, owner string) (val rt.WhoIs, found bool)
 	// Methods imported from bank should be defined here
 }

--- a/x/registry/types/expected_keepers.go
+++ b/x/registry/types/expected_keepers.go
@@ -46,3 +46,4 @@ type BankKeeper interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 	// Methods imported from bank should be defined here
 }
+

--- a/x/schema/keeper/keeper.go
+++ b/x/schema/keeper/keeper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	rt "github.com/sonr-io/sonr/x/registry/keeper"
 	"github.com/sonr-io/sonr/x/schema/types"
 )
 
@@ -20,6 +21,7 @@ type (
 
 		capabilityKeeper types.CapabilityKeeper
 		bankKeeper       types.BankKeeper
+		registryKeeper   rt.Keeper
 	}
 )
 
@@ -29,7 +31,7 @@ func NewKeeper(
 	memKey sdk.StoreKey,
 	ps paramtypes.Subspace,
 
-	accountKeeper types.AccountKeeper, capabilityKeeper types.CapabilityKeeper, bankKeeper types.BankKeeper,
+	accountKeeper types.AccountKeeper, capabilityKeeper types.CapabilityKeeper, bankKeeper types.BankKeeper, registryKepper types.RegistryKeeper,
 ) *Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {

--- a/x/schema/types/expected_keepers.go
+++ b/x/schema/types/expected_keepers.go
@@ -3,6 +3,7 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	rt "github.com/sonr-io/sonr/x/registry/types"
 )
 
 type CapabilityKeeper interface {
@@ -18,5 +19,13 @@ type AccountKeeper interface {
 // BankKeeper defines the expected interface needed to retrieve account balances.
 type BankKeeper interface {
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	// Methods imported from bank should be defined here
+}
+
+// RegistryKeeper defines the expected interface needed to manage account did documents.
+type RegistryKeeper interface {
+	GetWhoIs(ctx sdk.Context, id string) (val rt.WhoIs, found bool)
+	FindWhoIsByAlias(ctx sdk.Context, alias string) (val rt.WhoIs, found bool)
+	GetWhoIsFromOwner(ctx sdk.Context, owner string) (val rt.WhoIs, found bool)
 	// Methods imported from bank should be defined here
 }


### PR DESCRIPTION
Inject RegistryKeeper as a expected type into Bucket and Schema modules.

## Changes

* Introduce RegistryKeeper into Schema
* Introduce RegistryKeeper into Bucket

## Checklist

* [ ] Unit tests
* [ ] Documentation

Fixes #618
Connects

<img width="10" height="9" src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" "> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples here.