### PR TITLE
Fix: base64 decode length on files

### DIFF
--- a/pkg/motor/document_builder.go
+++ b/pkg/motor/document_builder.go
@@ -131,11 +131,12 @@ func normalizeDocument(schema id.Schema, doc map[string]interface{}) (map[string
 		// json.Unmarshal encodes byte arrays as base64 strings
 		case st.Kind_BYTES:
 			if by, ok := v.(string); ok {
-				res := make([]byte, base64.StdEncoding.EncodedLen(len(by)))
-				if _, err := base64.StdEncoding.Decode(res, []byte(by)); err != nil {
+				res := make([]byte, base64.StdEncoding.DecodedLen(len(by)))
+				n, err := base64.StdEncoding.Decode(res, []byte(by))
+				if err != nil {
 					return nil, err
 				}
-				result[k] = res
+				result[k] = res[0:n]
 			} else {
 				result[k] = v
 			}


### PR DESCRIPTION

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>