### PR TITLE
Resolve Wallet Encryption Vulnerability, Fix BLOK-32

### DIFF
--- a/pkg/crypto/mpc/wallet.go
+++ b/pkg/crypto/mpc/wallet.go
@@ -224,25 +224,13 @@ func (w *Wallet) CreateInitialShards() (dscShard, pskShard, recShard []byte, unu
 		return
 	}
 
-	// sign unused shards using MPC
-	// TODO: this is insecure! We're signing but should be encrypting.
-	// Can't encrypt with ECDSA. Is that the only encryption supported by mpc?
+	// list bank shards
 	for i := 0; i < len(ss); i++ {
 		u, ok := ss[fmt.Sprintf("bank%d", i+1)]
 		if !ok {
 			continue
 		}
-		sig, e := w.Sign([]byte(u))
-		if e != nil {
-			err = e
-			return
-		}
-		sSig, e := SerializeSignature(sig)
-		if e != nil {
-			err = e
-			return
-		}
-		unused = append(unused, sSig)
+		unused = append(unused, u)
 	}
 	if len(unused) == 0 {
 		err = errors.New("no backup shards")

--- a/pkg/motor/login.go
+++ b/pkg/motor/login.go
@@ -73,6 +73,9 @@ func (mtr *motorNodeImpl) LoginWithKeys(request mt.LoginWithKeysRequest) (mt.Log
 		whoIs = whoIsResp.WhoIs
 	}
 
+	// setup encryption key
+	mtr.encryptionKey = request.AesPskKey
+
 	// TODO: this is a hacky workaround for the Id not being populated in the DID document
 	whoIs.DidDocument.Id = did.CreateDIDFromAccount(whoIs.Owner)
 	mtr.DIDDocument, err = whoIs.DidDocument.ToPkgDoc()

--- a/pkg/motor/motor.go
+++ b/pkg/motor/motor.go
@@ -45,7 +45,10 @@ type motorNodeImpl struct {
 	tempDir    string
 	clientMode mt.ClientMode
 
-	// Sharding
+	// AES encryption key
+	encryptionKey []byte
+
+	// sharding
 	deviceShard   []byte
 	sharedShard   []byte
 	recoveryShard []byte

--- a/pkg/motor/motor_test.go
+++ b/pkg/motor/motor_test.go
@@ -1,19 +1,17 @@
 package motor
 
 import (
-	"testing"
-
 	"github.com/sonr-io/sonr/pkg/client"
 
 	rt "github.com/sonr-io/sonr/x/registry/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func (suite *MotorTestSuite) Test_DecodeTxData(t *testing.T) {
+func (suite *MotorTestSuite) Test_DecodeTxData() {
 	data := "0A91010A242F736F6E72696F2E736F6E722E72656769737472792E4D736743726561746557686F497312691267122A736E723134373071366D3476776D6537346A376D3573326364773939357A35796E6B747A726D377A35371A31122F6469643A736E723A3134373071366D3476776D6537346A376D3573326364773939357A35796E6B747A726D377A353730BC8FA197063801"
 
 	mcr := &rt.MsgCreateWhoIsResponse{}
 	err := client.DecodeTxResponseData(data, mcr)
-	assert.NoError(t, err, "decodes tx data successfully")
-	assert.Equal(t, "snr1470q6m4vwme74j7m5s2cdw995z5ynktzrm7z57", mcr.WhoIs.Owner)
+	assert.NoError(suite.T(), err, "decodes tx data successfully")
+	assert.Equal(suite.T(), "snr1470q6m4vwme74j7m5s2cdw995z5ynktzrm7z57", mcr.WhoIs.Owner)
 }

--- a/pkg/motor/registry_test.go
+++ b/pkg/motor/registry_test.go
@@ -66,6 +66,7 @@ func (suite *MotorTestSuite) Test_LoginWithKeys() {
 }
 
 func Test_LoginWithKeyring(t *testing.T) {
+	const ADDR = "snr19c99rqjsts86mm4t6u8qzy2al3ghkfgu7f2zua"
 	req := mt.LoginRequest{
 		AccountId: ADDR,
 		Password:  "password123",


### PR DESCRIPTION
Replaces wallet signing of vault shards with encryption using PSK. The PSK works as a good encryption key because it
1. is a symmetric key that can be used for encryption and decryption
2. is always required to create an account/sign in
3. is shared between all devices, so no need to keep track of multiple encryption keys

## Changes
- Replace shard signing with encryption
- Add a new `encryptionKey` property to `motorNodeImpl`

Fixes #680 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>