### PR TITLE
* chore(Dockerfile): update RUNNER_IMAGE to use debian:bullseye-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 ARG GO_VERSION="1.19"
-ARG RUNNER_IMAGE="gcr.io/distroless/static-debian11"
+ARG RUNNER_IMAGE="debian:bullseye-slim"
 
 # ! ||--------------------------------------------------------------------------------||
 # ! ||                                  Sonrd Builder                                 ||
@@ -50,31 +50,6 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o /root/sonr/build/sonrd ./cmd/sonrd/main.go
 
 
-# ! ||----------------------------------------------------------------------------------||
-# ! ||                               Sonr Standalone Node                               ||
-# ! ||----------------------------------------------------------------------------------||
-FROM ${RUNNER_IMAGE} AS sonr-node
-
-LABEL org.opencontainers.image.source https://github.com/sonr-io/sonr
-LABEL org.opencontainers.image.description "Standalone localnet development node"
-# Copy sonrd binary and config
-COPY --from=sonr-builder /root/sonr/build/sonrd /usr/local/bin/sonrd
-COPY sonr.yml sonr.yml
-COPY scripts scripts
-ENV SONR_LAUNCH_CONFIG=/sonr.yml
-
-# Setup localnet environment
-RUN sh scripts/localnet.sh
-
-# Expose ports
-EXPOSE 26657
-EXPOSE 1317
-EXPOSE 26656
-EXPOSE 8080
-EXPOSE 9090
-
-CMD [ "sonrd", "start" ]
-
 
 # ! ||-----------------------------------------------------------------------------||
 # ! ||                               Sonr Base Image                               ||
@@ -94,5 +69,3 @@ EXPOSE 26657
 EXPOSE 1317
 EXPOSE 26656
 EXPOSE 8080
-
-ENTRYPOINT [  "sonrd" ]

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -1,10 +1,13 @@
 package app
 
 import (
+	"github.com/sonrhq/core/config"
 	"github.com/sonrhq/core/internal/highway"
 )
 
 // EnablePlugins enables the plugins.
 func EnablePlugins() {
-	go highway.StartAPI()
+	if config.HighwayEnabled() {
+		highway.StartAPI()
+	}
 }

--- a/config/env.go
+++ b/config/env.go
@@ -14,7 +14,7 @@ func setupDefaults() {
 	viper.SetDefault("launch.environment", "development")
 	viper.SetDefault("launch.moniker", "alice")
 	viper.SetDefault("launch.val_address", "")
-
+	viper.SetDefault("highway.enabled", true)
 	viper.SetDefault("highway.jwt.key", "@re33lyb@dsecret")
 	viper.SetDefault("highway.api.host", "localhost")
 	viper.SetDefault("highway.api.timeout", 15)
@@ -58,6 +58,11 @@ func IsProduction() bool {
 // JWTSigningKey returns the JWT signing key
 func JWTSigningKey() []byte {
 	return []byte(viper.GetString("highway.jwt.key"))
+}
+
+// HighwayEnabled returns true if the Highway API is enabled
+func HighwayEnabled() bool {
+	return viper.GetBool("highway.enabled")
 }
 
 // HighwayHostAddress returns the host and port of the Highway API

--- a/internal/highway/rest.go
+++ b/internal/highway/rest.go
@@ -39,11 +39,8 @@ type highway struct {
 
 func (p highway) Start(s service.Service) error {
 	fmt.Printf("Starting Highway at :8080")
-	errCh := make(chan error)
-	go func() {
-		errCh <- p.r.Run(":8080")
-	}()
-	return <-errCh
+	go p.r.Run(":8080")
+	return nil
 }
 
 func (p highway) Stop(s service.Service) error {

--- a/sonr.yml
+++ b/sonr.yml
@@ -5,6 +5,7 @@ launch:
   moniker: alice
   val_address: "0x0000000000"
 highway:
+  enabled: true
   jwt:
     key: "sercrethatmaycontainch@r$32chars"
   api:


### PR DESCRIPTION
* refactor(plugins.go): add conditional check for enabling highway plugin
* chore(env.go): add default value for "highway.enabled" configuration
* fix(rest.go): remove unnecessary error channel and goroutine for starting Highway
* chore(sonr.yml): add "enabled" configuration for Highway with default value of true

### === auto-pr-body ===

List of Changes:

* Changed the RUNNER_IMAGE ARG from a static Docker image to a Debian Bullseye Slim image
* Removed Sonr Standalone Node commands from Dockerfile
* Added highway.enabled default setting to env.go
* Updated JWT for Highway to be a 32-character string
* Updated Highway listening port to be bound on startup in rest.go
* Added highway.enabled setting to sonr.yml