### PR TITLE
* chore(.goreleaser.yaml): update libwasmvm_muslc.x86_64.a download U…

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
         - CC=x86_64-linux-gnu-gcc
     hooks:
       pre:
-        - wget {{ .Env.WASMVM_URL }}/v1.2.4/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
+        - wget {{ .Env.WASMVM_URL }}/v1.3.0/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
     main: ./cmd/sonrd
     binary: sonrd
     goos:
@@ -46,8 +46,7 @@ builds:
         - CC=aarch64-linux-gnu-gcc
     hooks:
       pre:
-        #- wget {{ .Env.WASMVM_URL }}/v1.2.4/libwasmvm_muslc.aarch64.a -O /lib/libwasmvm_muscl.a
-        - wget {{ .Env.WASMVM_URL }}/v1.2.4/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
+        - wget {{ .Env.WASMVM_URL }}/v1.3.0/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
     main: ./cmd/sonrd
     binary: sonrd
     goos:
@@ -76,7 +75,7 @@ builds:
     binary: sonrd
     hooks:
       pre:
-        - wget {{ .Env.WASMVM_URL }}/v1.2.4/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+        - wget {{ .Env.WASMVM_URL }}/v1.3.0/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
     env:
       - CC=o64-clang
       - CGO_LDFLAGS=-L/lib
@@ -106,7 +105,7 @@ builds:
     binary: sonrd
     hooks:
       pre:
-        - wget {{ .Env.WASMVM_URL }}/v1.2.4/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+        - wget {{ .Env.WASMVM_URL }}/v1.3.0/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
     env:
       - CC=oa64-clang
       - CGO_LDFLAGS=-L/lib


### PR DESCRIPTION
### === auto-pr-body ===

Summary:
This pull request updates the versions of libwasmvm_muslc and libwasmvmstatic_darwin on the x86_64 and aarch64 platforms and removes a duplicate wget command from the aarch64 platform.

List of Changes:
• Changed target version of libwasmvm_muslc from v1.2.4 to v1.3.0 for x86_64 and aarch64 platforms.
• Removed a duplicate wget command for the aarch64 platform.
• Changed target version of libwasmvmstatic_darwin from v1.2.4 to v1.3.0 for both clang compilers.

Refactoring Target:
• Consolidate versions of libraries on different platforms to make code more maintainable and easily updated in the future.
• Create a single parameter or variable for the wget command, pointing the pull request for the relevant version.