### PR TITLE
Fix/actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   bump-version:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     name: Bump Current Version
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
   push:
     tags:
       - v*
+    branches:
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change ensures that the workflow triggers on pushes to the `main` branch instead of the `develop` branch.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R9-R17): Updated the workflow to trigger on pushes to the `main` branch and modified the condition to check if the base reference of the pull request is `main`.