### PR TITLE
test: Add commitizen dry run step to checks workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -113,6 +113,14 @@ jobs:
           go-version: "1.23"
           check-latest: true
 
+      - name: Commitizen Dry Run
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          push: false
+          dry_run: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+
       - name: Check GoReleaser Config
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,9 +21,8 @@ jobs:
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          push: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
+          push: false
+
       - name: Push using ssh
         run: |
           git push origin main --tags


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to improve the commit process and configuration checks. The most important changes include adding a dry run for Commitizen in the checks workflow and modifying the merge workflow to push changes using SSH.

Improvements to commit process:

* [`.github/workflows/checks.yml`](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165R116-R123): Added a new step for Commitizen dry run to ensure commit messages follow the conventional commit format without actually pushing changes.

Configuration changes:

* [`.github/workflows/merge.yml`](diffhunk://#diff-bdb37b2ad65e049a0fc043e88813fdcf7ca0118abc11d99bbda676adfcbbb5a1L24-R25): Modified the Commitizen action to disable pushing changes directly and instead push using SSH to improve security and control over the merge process.