### PR TITLE
chore: remove redundant variable declarations in for loops

### DIFF
--- a/x/svc/keeper/msg_server_test.go
+++ b/x/svc/keeper/msg_server_test.go
@@ -38,7 +38,6 @@ func TestParams(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := f.msgServer.UpdateParams(f.ctx, tc.request)
 
@@ -103,7 +102,6 @@ func TestInitiateDomainVerification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			msg := &types.MsgInitiateDomainVerification{
 				Creator: tc.creator,
@@ -198,7 +196,6 @@ func TestVerifyDomain(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			msg := &types.MsgVerifyDomain{
 				Creator: tc.creator,
@@ -299,7 +296,6 @@ func TestRegisterService(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			msg := &types.MsgRegisterService{
 				Creator:              tc.creator,


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Internal test code maintenance and cleanup with no user-facing changes.

---

*This release contains no new features or user-visible updates.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->